### PR TITLE
Added support to links on fields

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -61,6 +61,10 @@ export class DataSource extends DataSourceApi<MyQuery, MyDataSourceOptions> {
           if ('displayName' in field) {
             outputField.config.displayName = field['displayName'];
           }
+          // add links if exist
+          if ('links' in field) {                                                                                                                                                                                                                                                         
+            outputField.config['links'] = field['links'];                                                                                                                                                                                                                                 
+          } 
           outputFields.push(outputField);
         });
         return outputFields;


### PR DESCRIPTION
This solves issue #20 and is a very simple (3 line solution).

the way to use it is by specifying a links array in the fields JSON

`{
  "edges_fields": [
    {
      "field_name": "id",
      "type": "string"
    },
    {
      "field_name": "source",
      "type": "string"
    },
    {
      "field_name": "target",
      "type": "string"
    },
    {
      "field_name": "mainStat",
      "type": "number"
    }
  ],
  "nodes_fields": [
    {
      "field_name": "id",
      "type": "string",
      "links": [
          {
               "title": "Section One/First Link",
               "url": "https://google.com/${__data.fields.title}"
           },
           {
               "title": "Section One/Second Link",
               "url": "https://google.com"
           },
           {
               "title": "Section One/Second Link",
               "url": "https://google.com"
           }, 
    },
    {
      "field_name": "title",
      "type": "string"
    },
    {
      "field_name": "mainStat",
      "type": "string"
    },
    {
      "field_name": "secondaryStat",
      "type": "number"
    },
    {
      "color": "red",
      "field_name": "arc__failed",
      "type": "number"
    },
    {
      "color": "green",
      "field_name": "arc__passed",
      "type": "number"
    },
    {
      "displayName": "Role",
      "field_name": "detail__role",
      "type": "string"
    }
  ]
}`


This way it also supports all the internal links and stuff that Node Graph have on their example:
![image](https://user-images.githubusercontent.com/45238586/205308296-ca0fa2a1-ad92-4840-8641-4ba565448e22.png)
